### PR TITLE
(fix:nfl-picks): Add axios package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@babel/core": "^7.17.10",
     "@babel/plugin-proposal-class-properties": "^7.16.7",
+    "@babel/preset-env": "^7.17.10",
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@types/koa": "^2.13.4",
@@ -44,7 +45,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
-    "@babel/preset-env": "^7.17.10",
+    "axios": "0.27.2",
     "formik": "^2.2.9",
     "global": "^4.4.0",
     "grommet": "^2.23.0",


### PR DESCRIPTION
Quick PR to address a minor issue I encountered when getting this project set up locally:

- Adds axios package dependency to fix runtime module resolution error
- Moves @babel/preset-env package from dependencies to devDependencies